### PR TITLE
Fix build error on Unity 2021

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -45,9 +45,5 @@
             </intent-filter>
         </service>
 
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
-
     </application>
 </manifest>

--- a/Assets/Plugins/Android/res.meta
+++ b/Assets/Plugins/Android/res.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9917835adadb342369f3eba9b149722a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Android/res/values.meta
+++ b/Assets/Plugins/Android/res/values.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 756d167d8c648468eac26ea5763f89c8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Android/res/values/version.xml
+++ b/Assets/Plugins/Android/res/values/version.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="google_play_services_version">8298000</integer>
-</resources>

--- a/Assets/Plugins/Android/res/values/version.xml.meta
+++ b/Assets/Plugins/Android/res/values/version.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6cdfb054d70b748f0932de55286eb0f4
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
* Fix error when building native Android on Unity 2021
Providing Android resources in Assets/Plugins/Android/res was removed, please move your resources to an AAR or an Android Library.